### PR TITLE
standard out should only be written into one variable for IP/MAC detection

### DIFF
--- a/src/linux_auto_dics_multi.py
+++ b/src/linux_auto_dics_multi.py
@@ -283,7 +283,6 @@ def grab_and_post_inventory_data(machine_name):
             device_name_in_d42 = msg['msg'][2]
             stdin, stdout, stderr = ssh.exec_command("/sbin/ifconfig -a") #TODO add just macs     without IPs
             data_err = stderr.readlines()
-            data_out = stdout.readlines()
             if not data_err:
                 ipinfo = stdout.readlines()
 


### PR DESCRIPTION
The double variable assignment of standard out breaks the IP/MAC detection
